### PR TITLE
use correct framework

### DIFF
--- a/IoT.ClientApi.ConsoleApp/IoT.ClientApi.ConsoleApp.csproj
+++ b/IoT.ClientApi.ConsoleApp/IoT.ClientApi.ConsoleApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	  <LanguageVersion>12.0</LanguageVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <Reference Include="IoT.KiotaClient">
-      <HintPath>bin\Debug\net80\IoT.KiotaClient.dll</HintPath>
+      <HintPath>bin\Debug\net8.0\IoT.KiotaClient.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/IoT.GrainImplementation/IoT.GrainImplementation.csproj
+++ b/IoT.GrainImplementation/IoT.GrainImplementation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	  <LanguageVersion>12.0</LanguageVersion>
   </PropertyGroup>
 

--- a/IoT.GrainInterfaces/IoT.GrainInterfaces.csproj
+++ b/IoT.GrainInterfaces/IoT.GrainInterfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LanguageVersion>12.0</LanguageVersion>
 
   </PropertyGroup>

--- a/IoT.KiotaClient/IoT.KiotaClient.csproj
+++ b/IoT.KiotaClient/IoT.KiotaClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LanguageVersion>12.0</LanguageVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/IoT.SiloHostApp/IoT.SiloHostApp.csproj
+++ b/IoT.SiloHostApp/IoT.SiloHostApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LanguageVersion>12.0</LanguageVersion>
 	  <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>

--- a/IoT.WebApp/IoT.WebApp.csproj
+++ b/IoT.WebApp/IoT.WebApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LanguageVersion>12.0</LanguageVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 	  <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)